### PR TITLE
widen react dependency range to support react 18 and 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rct-router",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "description": "a router for react",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -35,12 +35,12 @@
   "devDependencies": {
     "@types/node": "24.10.1",
     "@types/qs": "6.14.0",
-    "@types/react": "18.3.1",
+    "@types/react": "19.2.14",
     "typescript": "5.9.3"
   },
   "dependencies": {
     "qs": "6.15.0",
-    "react": "18.3.1",
+    "react": "^18.3.1 || ^19.0.0",
     "url-pattern": "1.0.3"
   }
 }


### PR DESCRIPTION
## Why
`react` was pinned to `18.3.1` as a regular `dependency`. When a host project upgrades to React 19, npm has to install a nested `react@18.3.1` inside `node_modules/rct-router/node_modules/react` to satisfy the exact pin, leaving the app with two React copies in memory → "Invalid hook call" at runtime.

We hit this on the GainLife jarvis monorepo while upgrading to Mantine 9 + React 19.

## What
- `dependencies.react`: `18.3.1` → `^18.3.1 || ^19.0.0` so npm can hoist whichever React the host is using (no more nested copy).
- `devDependencies.@types/react`: `18.3.1` → `19.2.14` so the package builds against the newest React types while still supporting both runtimes.
- Version bumped to 5.0.8 (non-breaking — existing React 18 hosts still resolve cleanly).
- No source changes needed; `tsc` passes against React 19 types.

## Test
- `npm install && npx tsc` clean
- Verified consuming app no longer gets a nested `node_modules/rct-router/node_modules/react` after install on a React 19 host.